### PR TITLE
currentAppleLanguage(): read up to a hyphen (if exists) to handle language ids longer than 2 chars (e.g. fil for Filipino)

### DIFF
--- a/MOLH/MOLHLanguage.swift
+++ b/MOLH/MOLHLanguage.swift
@@ -31,9 +31,11 @@ open class MOLHLanguage {
         let userdef = UserDefaults.standard
         let langArray = userdef.object(forKey: APPLE_LANGUAGE_KEY) as! NSArray
         let current = langArray.firstObject as! String
-        let endIndex = current.index(current.startIndex, offsetBy: 2)
-        let currentWithoutLocale = current[current.startIndex..<endIndex]
-        return String(currentWithoutLocale)
+        if let hyphenIndex = current.firstIndex(of: "-") {
+            return String(current[..<hyphenIndex])
+        } else {
+            return current
+        }
     }
     
     /**


### PR DESCRIPTION
The current implementation of `currentAppleLanguage()` takes the first two characters of the first language identifier returned by the `APPLE_LANGUAGE_KEY` key. However, this may not work with locales with three-lettered identifiers (e.g. `fil` for Filipino). So, it seemed to me that that logic was there to handle hyphenated locale identifiers (e.g. en-US). So, I suggest reading up to that hyphen is a better solution. Thoughts?